### PR TITLE
Added error to  be displayed in case empty file is uploaded

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,18 +18,22 @@ if st.sidebar.button("Reset App"):
     st.rerun()  # Force Streamlit to refresh the app
 
 if uploaded_file is not None:
-    try:
+    if uploaded_file.size == 0:
+        st.error("The uploaded file is empty. Please upload a valid WhatsApp chat export.")
+        st.stop()  
+    else:
+        try:
         # Read file as bytes and decode to string
-        bytes_data = uploaded_file.read()
-        data = bytes_data.decode("utf-8")
-        df = preprocessor.preprocess(data)
+         bytes_data = uploaded_file.read()
+         data = bytes_data.decode("utf-8")
+         df = preprocessor.preprocess(data)
         
         # Store dataframe in session state
-        st.session_state.dataframe = df
-    except UnicodeDecodeError as e:
-        st.error(f"Decode Error: {e}")
-    except Exception as e:
-        st.error(f"An error occurred: {e}")
+         st.session_state.dataframe = df
+        except UnicodeDecodeError as e:
+         st.error(f"Decode Error: {e}")
+        except Exception as e:
+         st.error(f"An error occurred: {e}")
     
     # Build user list from the dataframe
     user_list = df['Sender'].unique().tolist()


### PR DESCRIPTION


Resolves #2 

## Description

In case an empty file is uploaded an error will be displayed and the file wont be tried to be analysed

<img width="1092" alt="Screenshot 2025-03-29 at 2 11 48 PM" src="https://github.com/user-attachments/assets/1bc0b835-4099-4b9f-b666-342d74a5ab1a" />

